### PR TITLE
Fix warning

### DIFF
--- a/Lady/RGBToneCurveFilter.swift
+++ b/Lady/RGBToneCurveFilter.swift
@@ -353,7 +353,7 @@ extension RGBToneCurveFilter {
 private extension UnsafeMutablePointer {
     static func calloc<T>(_ count: Int, initialValue: T) -> UnsafeMutablePointer<T> {
         let ptr = UnsafeMutablePointer<T>.allocate(capacity: count)
-        ptr.initialize(from: repeatElement(initialValue, count: count))
+        ptr.initialize(to: initialValue, count: count)
         return ptr
     }
 }


### PR DESCRIPTION
In Swift 3.1, UnsafeMutablePointer.initialize(from:) is deprecated